### PR TITLE
Initialize Git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+realm-*.zip filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Some yarn package cache is large enough that GitHub rejects our commit, thus we need to move them to Git LFS