### PR TITLE
Switch back to JSC to avoid crash

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -78,7 +78,7 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    enableHermes: true,  // clean and rebuild if changing
+    enableHermes: false,  // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"


### PR DESCRIPTION
For now, the stable version of realm does not support Hermes.
Once it does though, we can begin switching back if possible.