### PR TITLE
Add upload artifact stage for main branch analysis

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,3 +22,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: javascript-test
+          path: |
+            coverage/
+            test-report.xml


### PR DESCRIPTION
This will remove the need to do a separate test run just to gather the coverage report for SonarCloud