### PR TITLE
Add cron schedule for yarn cache persist workflow

### DIFF
--- a/.github/workflows/main-branch-persist-yarn-cache.yml
+++ b/.github/workflows/main-branch-persist-yarn-cache.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
   workflow_dispatch:
+  schedule:
+    - cron: '0 12 * * 1,5'
 
 jobs:
   persist_cache:


### PR DESCRIPTION
The cache will be purged every 7 days, and we don't want that.

Therefore, we will trigger this workflow on a schedule to keep the cache updated.